### PR TITLE
Pass the virtual_host_scanner constructor arguments as a dict

### DIFF
--- a/VHostScan.py
+++ b/VHostScan.py
@@ -77,8 +77,9 @@ def main():
     if(arguments.ignore_content_length > 0):
         print("[>] Ignoring Content length: %s" % (arguments.ignore_content_length))
 
-    scanner = virtual_host_scanner( arguments.target_hosts, arguments.base_host, wordlist, arguments.port, arguments.real_port, arguments.ssl, 
-                                    arguments.unique_depth, arguments.ignore_http_codes, arguments.ignore_content_length, arguments.fuzzy_logic, arguments.add_waf_bypass_headers)
+    scanner_args = vars(arguments)
+    scanner_args.update({'target': arguments.target_hosts, 'wordlist': wordlist})
+    scanner = virtual_host_scanner(**scanner_args)
     
     scanner.scan()
     output = output_helper(scanner, arguments)

--- a/lib/core/virtual_host_scanner.py
+++ b/lib/core/virtual_host_scanner.py
@@ -20,18 +20,18 @@ class virtual_host_scanner(object):
         output: folder to write output file to
     """
      
-    def __init__(self, target, base_host, wordlist, port=80, real_port=80, ssl=False, unique_depth=1, ignore_http_codes='404', ignore_content_length=0, fuzzy_logic=False, add_waf_bypass_headers=False):
+    def __init__(self, target, wordlist, **kwargs):
         self.target = target
-        self.base_host = base_host
-        self.port = int(port)
-        self.real_port = int(real_port)
-        self.ignore_http_codes = list(map(int, ignore_http_codes.replace(' ', '').split(',')))
-        self.ignore_content_length = ignore_content_length
         self.wordlist = wordlist
-        self.unique_depth = unique_depth
-        self.ssl = ssl
-        self.fuzzy_logic = fuzzy_logic
-        self.add_waf_bypass_headers = add_waf_bypass_headers
+        self.base_host = kwargs.get('base_host')
+        self.port = int(kwargs.get('port', 80))
+        self.real_port = int(kwargs.get('real_port', 80))
+        self.ignore_content_length = int(kwargs.get('ignore_content_length', 0))
+        self.ssl = kwargs.get('ssl', False)
+        self.fuzzy_logic = kwargs.get('fuzzy_logic', False)
+        self.add_waf_bypass_headers = kwargs.get('add_waf_bypass_headers', False)
+        self.unique_depth = int(kwargs.get('unique_depth', 1))
+        self.ignore_http_codes = kwargs.get('ignore_http_codes', '404')
 
         # this can be made redundant in future with better exceptions
         self.completed_scan=False
@@ -42,6 +42,13 @@ class virtual_host_scanner(object):
         # store associated data for discovered hosts in array for oN, oJ, etc'
         self.hosts = []
 
+    @property
+    def ignore_http_codes(self):
+        return self._ignore_http_codes
+
+    @ignore_http_codes.setter
+    def ignore_http_codes(self, codes):
+        self._ignore_http_codes = [int(code) for code in codes.replace(' ', '').split(',')]
 
     def scan(self):
         if not self.base_host:


### PR DESCRIPTION
With the current implementation, adding a new input parameter is a three
step process:

  1. Add its definition to the ArgumentParser instance
  2. Change the virtual_host_scanner constructor signature
  3. Change the virtual_host_scanner instantiation arguments
  4. Set the instance property value within the virtual_host_scanner

By receiving a dict directly as a constructor argument, steps 2 and 3
become unnecessary.