### PR TITLE
Closes #68 - Add exceptions for missing PTR records

### DIFF
--- a/VHostScan.py
+++ b/VHostScan.py
@@ -2,8 +2,8 @@
 
 import os
 import sys
+import dns.resolver
 from argparse import ArgumentParser
-from dns.resolver import Resolver
 from socket import gethostbyaddr
 from lib.core.virtual_host_scanner import *
 from lib.helpers.output_helper import *
@@ -88,14 +88,14 @@ def main():
     if not arguments.no_lookup:
         try:
             print("[+] Resolving DNS for additional wordlist entries")
-            for ip in Resolver().query(arguments.target_hosts, 'A'):
+            for ip in dns.resolver.query(arguments.target_hosts, 'A'):
                 host, aliases, ips = gethostbyaddr(str(ip))
                 wordlist.append(str(ip))
                 wordlist.append(host)
                 wordlist.extend(aliases)
-        except (NXDOMAIN):
+        except (dns.resolver.NXDOMAIN):
             print("[!] Couldn't find any records (NXDOMAIN)")
-        except (NoAnswer):
+        except (dns.resolver.NoAnswer):
             print("[!] Couldn't find any records (NoAnswer)")
 
     scanner_args = vars(arguments)

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -86,11 +86,17 @@ def main():
         print("[>] First hit is set.")
 
     if not arguments.no_lookup:
-        for ip in Resolver().query(arguments.target_hosts, 'A'):
-            host, aliases, ips = gethostbyaddr(str(ip))
-            wordlist.append(str(ip))
-            wordlist.append(host)
-            wordlist.extend(aliases)
+        try:
+            print("[+] Resolving DNS for additional wordlist entries")
+            for ip in Resolver().query(arguments.target_hosts, 'A'):
+                host, aliases, ips = gethostbyaddr(str(ip))
+                wordlist.append(str(ip))
+                wordlist.append(host)
+                wordlist.extend(aliases)
+        except (dns.resolver.NXDOMAIN):
+            print("[!] Couldn't find any records (NXDOMAIN)")
+        except (dns.resolver.NoAnswer):
+            print("[!] Couldn't find any records (NoAnswer)")
 
     scanner_args = vars(arguments)
     scanner_args.update({

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -93,9 +93,9 @@ def main():
                 wordlist.append(str(ip))
                 wordlist.append(host)
                 wordlist.extend(aliases)
-        except (dns.resolver.NXDOMAIN):
+        except (NXDOMAIN):
             print("[!] Couldn't find any records (NXDOMAIN)")
-        except (dns.resolver.NoAnswer):
+        except (NoAnswer):
             print("[!] Couldn't find any records (NoAnswer)")
 
     scanner_args = vars(arguments)

--- a/lib/core/__version__.py
+++ b/lib/core/__version__.py
@@ -2,4 +2,4 @@
 # |V|H|o|s|t|S|c|a|n|  Developed by @codingo_ & @__timk
 # +-+-+-+-+-+-+-+-+-+  https://github.com/codingo/VHostScan
 
-__version__ = '1.6.2'
+__version__ = '1.6.3'


### PR DESCRIPTION
Added exception handling around the DNS lookup to handle cases where PTR records may not be present, or a timeout occurs. Raise by @timkent in #68.