### PR TITLE
Closes #6 - Output grepable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ $ pip install -r requirements.txt
 | --user-agent | Specify a user agent to use for scans. |
 | --waf | If set then simple WAF bypass headers will be sent. |
 | -oN OUTPUT_NORMAL | Normal output printed to a file when the -oN option is specified with a filename argument. |
+| -oG OUTPUT_GREPABLE | Grepable output printed to a file when the -oG is specified with a filename argument. |
 | -oJ OUTPUT_JSON | JSON output printed to a file when the -oJ option is specified with a filename argument. |
 | - | By passing a blank '-' you tell VHostScan to expect input from stdin (pipe). |
 

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -120,7 +120,11 @@ def main():
 
     if(arguments.output_json):
         output.output_json(arguments.output_json)
-        print("\n[+] Writing json ouptut to %s" % arguments.output_json)
+        print("\n[+] Writing json output to %s" % arguments.output_json)
+
+    if(arguments.output_grepable):
+        output.output_grepable(arguments.output_grepable)
+        print("\n[+] Writing grepable ouptut to %s" % arguments.output_json)
 
 
 if __name__ == "__main__":

--- a/lib/core/__version__.py
+++ b/lib/core/__version__.py
@@ -2,4 +2,4 @@
 # |V|H|o|s|t|S|c|a|n|  Developed by @codingo_ & @__timk
 # +-+-+-+-+-+-+-+-+-+  https://github.com/codingo/VHostScan
 
-__version__ = '1.6.4'
+__version__ = '1.7'

--- a/lib/helpers/output_helper.py
+++ b/lib/helpers/output_helper.py
@@ -24,6 +24,14 @@ class output_helper(object):
         output += self.output_normal_detail()
         file.write_file(output)
 
+    def write_grepable(self, filename):
+        file = file_helper(filename)
+
+        output = self.generate_header()
+        output += self.output_grepable_detail()
+
+        file.write_file(output)
+
     def output_normal_likely(self):
         uniques = False
         depth = str(self.scanner.unique_depth)
@@ -104,6 +112,16 @@ class output_helper(object):
 
             for key in host.keys:
                 output += "\n\t{}".format(key)
+
+        return output
+
+    def output_grepable_detail(self):
+        for host in self.scanner.hosts:
+            output += "\n{}\t{}\t{}".format(
+                str(host.hostname),
+                str(host.response_code),
+                str(host.hash)
+            )
 
         return output
 

--- a/lib/input.py
+++ b/lib/input.py
@@ -117,6 +117,12 @@ class cli_argument_parser(object):
                  'specified with a filename argument.'
         )
 
+        output.add_argument(
+            '-oG', dest='output_grepable',
+            help='Grepable output printed to a file when the -oG option is '
+                 'specified with a filename argument.'
+        )
+
         user_agent = parser.add_mutually_exclusive_group()
         user_agent.add_argument(
             '--random-agent', dest='random_agent', action='store_true',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -30,6 +30,7 @@ def test_parse_arguments_default_value(tmpdir):
         'add_waf_bypass_headers': False,
         'output_normal': None,
         'output_json': None,
+        'output_grepable' : None,
         'stdin': False,
         'ssl': False,
     }
@@ -83,6 +84,7 @@ def test_parse_arguments_custom_arguments(tmpdir):
         'add_waf_bypass_headers': True,
         'output_normal': '/tmp/on',
         'output_json': None,
+        'output_grepable' : None,
         'stdin': True,
     }
 


### PR DESCRIPTION
This adds output grepable. I'm still unsure of its utility since likely matches isn't easy to display in this format, open to suggestions?

At present I'm just writing out:

```
    def output_grepable_detail(self):
        for host in self.scanner.hosts:
            output += "\n{}\t{}\t{}".format(
                str(host.hostname),
                str(host.response_code),
                str(host.hash)
            )

        return output
```

Likely has some use, but merits further thought. We could merge this for now and amend as better use cases for it become more known.