### PR TITLE
Remove need for '-' flag to force stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ $ pip install -r requirements.txt
 | -oN OUTPUT_NORMAL | Normal output printed to a file when the -oN option is specified with a filename argument. |
 | -oG OUTPUT_GREPABLE | Grepable output printed to a file when the -oG is specified with a filename argument. |
 | -oJ OUTPUT_JSON | JSON output printed to a file when the -oJ option is specified with a filename argument. |
-| - | By passing a blank '-' you tell VHostScan to expect input from stdin (pipe). |
 
 
 ## Usage Examples
@@ -85,7 +84,7 @@ $ cat bank.htb | VHostScan.py -t 10.10.10.29 -
 ### STDIN and WordList
 You can still specify a wordlist to use along with stdin. In these cases wordlist information will be appended to stdin. For example:
 ```bash
-$ echo -e 'a.example.com\b.example.com' | VhostScan.py -t localhost -w ./wordlists/wordlist.txt -
+$ echo -e 'a.example.com\b.example.com' | VhostScan.py -t localhost -w ./wordlists/wordlist.txt
 ```
 ### Fuzzy Logic
 Here is an example with fuzzy logic enabled. You can see the last comparison is much more similar than the first two (it is comparing the content not the actual hashes):

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ cat bank.htb | VHostScan.py -t 10.10.10.29 -
 ### STDIN and WordList
 You can still specify a wordlist to use along with stdin. In these cases wordlist information will be appended to stdin. For example:
 ```bash
-$ echo -e 'a.example.com\b.example.com' | VhostScan.py -t localhost -w ./wordlists/wordlist.txt
+$ echo -e 'a.example.com\b.example.com' | VHostScan.py -t localhost -w ./wordlists/wordlist.txt
 ```
 ### Fuzzy Logic
 Here is an example with fuzzy logic enabled. You can see the last comparison is much more similar than the first two (it is comparing the content not the actual hashes):

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -35,7 +35,7 @@ def main():
     word_list_types = []
 
     default_wordlist = DEFAULT_WORDLIST_FILE \
-        if not sys.stdin.isatty() else None
+        if sys.stdin.isatty() else None
 
     if not sys.stdin.isatty():
         word_list_types.append('stdin')

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -34,9 +34,9 @@ def main():
     wordlist = []
     word_list_types = []
 
-    default_wordlist = DEFAULT_WORDLIST_FILE if not arguments.stdin else None
+    default_wordlist = DEFAULT_WORDLIST_FILE if not sys.stdin.isatty() else None
 
-    if arguments.stdin:
+    if not sys.stdin.isatty():
         word_list_types.append('stdin')
         wordlist.extend(list(line for line in sys.stdin.read().splitlines()))
 

--- a/VHostScan.py
+++ b/VHostScan.py
@@ -34,7 +34,8 @@ def main():
     wordlist = []
     word_list_types = []
 
-    default_wordlist = DEFAULT_WORDLIST_FILE if not sys.stdin.isatty() else None
+    default_wordlist = DEFAULT_WORDLIST_FILE \
+        if not sys.stdin.isatty() else None
 
     if not sys.stdin.isatty():
         word_list_types.append('stdin')

--- a/lib/core/__version__.py
+++ b/lib/core/__version__.py
@@ -2,4 +2,4 @@
 # |V|H|o|s|t|S|c|a|n|  Developed by @codingo_ & @__timk
 # +-+-+-+-+-+-+-+-+-+  https://github.com/codingo/VHostScan
 
-__version__ = '1.7'
+__version__ = '1.7.1'

--- a/lib/input.py
+++ b/lib/input.py
@@ -98,12 +98,6 @@ class cli_argument_parser(object):
             help='If set then simple WAF bypass headers will be sent.'
         )
 
-        parser.add_argument(
-            '-', dest='stdin', action='store_true', default=False,
-            help="By passing a blank '-' you tell VHostScan to expect input "
-                 "from stdin (pipe)."
-        )
-
         output = parser.add_mutually_exclusive_group()
         output.add_argument(
             '-oN', dest='output_normal',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -20,7 +20,7 @@ def test_parse_arguments_default_value(tmpdir):
         'real_port': False,
         'ignore_http_codes': '404',
         'ignore_content_length': 0,
-        'first_hit': False ,
+        'first_hit': False,
         'unique_depth': 1,
         'fuzzy_logic': False,
         'no_lookup': False,
@@ -31,7 +31,6 @@ def test_parse_arguments_default_value(tmpdir):
         'output_normal': None,
         'output_json': None,
         'output_grepable' : None,
-        'stdin': False,
         'ssl': False,
     }
     
@@ -60,7 +59,6 @@ def test_parse_arguments_custom_arguments(tmpdir):
         '--user-agent', 'some-user-agent',
         '--waf',
         '-oN', '/tmp/on',
-        '-',
     ]
 
     arguments = cli_argument_parser().parse(argv)
@@ -85,7 +83,6 @@ def test_parse_arguments_custom_arguments(tmpdir):
         'output_normal': '/tmp/on',
         'output_json': None,
         'output_grepable' : None,
-        'stdin': True,
     }
 
     assert vars(arguments) == expected_arguments


### PR DESCRIPTION
This patch removes the need for the '-' flag when using stdin and instead allows you to pipe into VHostScan directly at anytime. STDIN is checked prior to a commit.

Tested already on a Windows VM but still requires testing in Kali.