### PR TITLE
Supress insecure warnings within requests

### DIFF
--- a/lib/core/__version__.py
+++ b/lib/core/__version__.py
@@ -2,4 +2,4 @@
 # |V|H|o|s|t|S|c|a|n|  Developed by @codingo_ & @__timk
 # +-+-+-+-+-+-+-+-+-+  https://github.com/codingo/VHostScan
 
-__version__ = '1.8.1'
+__version__ = '1.8.2'

--- a/lib/core/virtual_host_scanner.py
+++ b/lib/core/virtual_host_scanner.py
@@ -9,6 +9,7 @@ from lib.core.discovered_host import *
 
 import urllib3
 urllib3.disable_warnings()
+requests.packages.urllib3.disable_warnings()
 
 DEFAULT_USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '\
                      'AppleWebKit/537.36 (KHTML, like Gecko) '\


### PR DESCRIPTION
Added the disable_warnings() call within the requests.packages.urllib3 package.
Fixes #84.