### PR TITLE
Update dynamic location random user agent list

### DIFF
--- a/VHostScan/lib/helpers/file_helper.py
+++ b/VHostScan/lib/helpers/file_helper.py
@@ -1,6 +1,10 @@
 import json
 import os
 
+from pkg_resources import resource_filename
+
+DEFAULT_UA_LIST = resource_filename(
+    'VHostScan', 'lib/ua-random-list.txt')
 
 class file_helper(object):
     """description of class"""
@@ -62,5 +66,5 @@ def get_combined_word_lists(argument):
 
 
 def load_random_user_agents():
-    with open('./lib/ua-random-list.txt') as f:
-        return f.readlines()
+    with open(DEFAULT_UA_LIST) as f:
+        return f.read().splitlines()


### PR DESCRIPTION
Hi there,

While testing your program, i'm getting error for random user agent mode because you are using static file location, when installing this program with `python setup.py install` it get binary alias as `VhostScan` pointing to **/usr/lib/python3.6/site-packages/VHostScan-1.21-py3.6.egg/VHostScan/VHostScan.py** but your function still use static location
```
 with open('./lib/ua-random-list.txt') as f:
```
Error
```
[>] Random User-Agent flag set.
Traceback (most recent call last):
  File "/usr/bin/VHostScan", line 11, in <module>
    load_entry_point('VHostScan==1.21', 'console_scripts', 'VHostScan')()
  File "/usr/lib/python3.6/site-packages/VHostScan-1.21-py3.6.egg/VHostScan/VHostScan.py", line 54, in main
    user_agents = load_random_user_agents()
  File "/usr/lib/python3.6/site-packages/VHostScan-1.21-py3.6.egg/VHostScan/lib/helpers/file_helper.py", line 65, in load_random_user_agents
    with open('./lib/ua-random-list.txt') as f:
FileNotFoundError: [Errno 2] No such file or directory: './lib/ua-random-list.txt'
```

So, i've added dynamic file location as you used before at wordlist_helper.py and change `readlines` to `read` function, so i can use `splitlines()` for fixing this issue:

```
raise ValueError('Invalid header value %r' % (values[i],))
ValueError: Invalid header value b'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36\n'
```
If you don't mind, i can implementing fake/random user agent function to this project, as you can see in my project:
https://github.com/aancw/Belati/blob/master/plugins/user_agents.py

Thanks!