### PR TITLE
Update IP validation to support IPv6

### DIFF
--- a/VHostScan/lib/helpers/wordlist_helper.py
+++ b/VHostScan/lib/helpers/wordlist_helper.py
@@ -74,6 +74,6 @@ class WordList:
 
     def valid_ip(self, address):
         try:
-            return ip_address(address.decode("utf8", "replace")) is not None
+            return ip_address(address) is not None
         except:
             return False

--- a/VHostScan/lib/helpers/wordlist_helper.py
+++ b/VHostScan/lib/helpers/wordlist_helper.py
@@ -74,9 +74,6 @@ class WordList:
 
     def valid_ip(self, address):
         try:
-            host_bytes = address.split('.')
-            valid = [int(b) for b in host_bytes]
-            valid = [b for b in valid if b >= 0 and b <= 255]
-            return len(host_bytes) == 4 and len(valid) == 4
+            return ip_address(address.decode("utf8", "replace")) != None
         except:
             return False

--- a/VHostScan/lib/helpers/wordlist_helper.py
+++ b/VHostScan/lib/helpers/wordlist_helper.py
@@ -1,7 +1,7 @@
 import sys
 from .file_helper import get_combined_word_lists
 from pkg_resources import resource_filename
-
+from ipaddress import ip_address
 
 DEFAULT_WORDLIST_FILE = resource_filename(
     'VHostScan', 'wordlists/virtual-host-scanning.txt')

--- a/VHostScan/lib/helpers/wordlist_helper.py
+++ b/VHostScan/lib/helpers/wordlist_helper.py
@@ -74,6 +74,6 @@ class WordList:
 
     def valid_ip(self, address):
         try:
-            return ip_address(address.decode("utf8", "replace")) != None
+            return ip_address(address.decode("utf8", "replace")) is not None
         except:
             return False

--- a/tests/helpers/test_wordlist_helper.py
+++ b/tests/helpers/test_wordlist_helper.py
@@ -48,14 +48,14 @@ class TestWordList(unittest.TestCase):
             self.assertEqual(wordlist, self.default_wordlist)
 
     def test_ip_using_prefix(self):
-        stdin_wordlist = ['127.0.0.1']
+        stdin_wordlist = ['127.0.0.1', '::1']
         prefix = 'dev-'
         with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
             wordlist, wordlist_types = self.wordlist.get_wordlist(None, prefix)
             self.assertEqual(wordlist, stdin_wordlist)
 
     def test_ip_using_suffix(self):
-        stdin_wordlist = ['127.0.0.1']
+        stdin_wordlist = ['127.0.0.1', '::1']
         suffix = 'test'
         with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
             wordlist, wordlist_types = self.wordlist.get_wordlist(None,None,suffix)

--- a/tests/helpers/test_wordlist_helper.py
+++ b/tests/helpers/test_wordlist_helper.py
@@ -48,14 +48,28 @@ class TestWordList(unittest.TestCase):
             self.assertEqual(wordlist, self.default_wordlist)
 
     def test_ip_using_prefix(self):
-        stdin_wordlist = ['127.0.0.1', '::1']
+        stdin_wordlist = ['127.0.0.1']
         prefix = 'dev-'
         with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
             wordlist, wordlist_types = self.wordlist.get_wordlist(None, prefix)
             self.assertEqual(wordlist, stdin_wordlist)
 
     def test_ip_using_suffix(self):
-        stdin_wordlist = ['127.0.0.1', '::1']
+        stdin_wordlist = ['127.0.0.1']
+        suffix = 'test'
+        with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
+            wordlist, wordlist_types = self.wordlist.get_wordlist(None,None,suffix)
+            self.assertEqual(wordlist,stdin_wordlist)
+
+    def test_ipv6_using_prefix(self):
+        stdin_wordlist = ['::1']
+        prefix = 'dev-'
+        with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
+            wordlist, wordlist_types = self.wordlist.get_wordlist(None, prefix)
+            self.assertEqual(wordlist, stdin_wordlist)
+
+    def test_ipv6_using_suffix(self):
+        stdin_wordlist = ['::1']
         suffix = 'test'
         with patch('VHostScan.lib.helpers.wordlist_helper.WordList.get_stdin_wordlist', return_value=stdin_wordlist):
             wordlist, wordlist_types = self.wordlist.get_wordlist(None,None,suffix)


### PR DESCRIPTION
I noticed that the way validation of ip addresses were being handled only supports ipv4, so I changed it to a built in method of ip validation.