### PR TITLE
Colorize Interface

### DIFF
--- a/VHostScan/VHostScan.py
+++ b/VHostScan/VHostScan.py
@@ -19,8 +19,13 @@ DEFAULT_WORDLIST_FILE = resource_filename(
 
 def print_banner():
     board_edge = t_white("+-+-+-+-+-+-+-+-+-+")
-    board_text = ''.join([ t_white(c) if i%2==0 else t_yellow(c) for i,c in enumerate("|V|H|o|s|t|S|c|a|n|") ])
-    
+    board_text = ''
+    for i, c in enumerate("|V|H|o|s|t|S|c|a|n|"):
+        if i % 2 == 0:
+            board_text += t_white(c)
+        else:
+            board_text += t_yellow(c)
+
     version = t_green("  v. %s" % __version__)
     developer = t_green("  Developed by @codingo_ & @__timk")
     repo = t_green("  https://github.com/codingo/VHostScan")
@@ -30,23 +35,27 @@ def print_banner():
     print(board_edge, repo)
     print()
 
+
 def extract_arguments():
     parser = cli_argument_parser()
     return parser.parse(sys.argv[1:])
+
 
 def main():
     arguments = extract_arguments()
 
     config_colorization(arguments.use_color)
-    
+
     print_banner()
-        
+
     wordlist_helper = WordList()
     wordlist, wordlist_types = wordlist_helper.get_wordlist(
         arguments.wordlists, arguments.prefix, arguments.suffix)
 
     if len(wordlist) == 0:
-        print(t_error("[!] No words found in provided wordlists, unable to scan."))
+        print(t_error(
+            "[!] No words found in provided wordlists, unable to scan."
+        ), end='')
         sys.exit(1)
 
     print(t_process(
@@ -70,9 +79,13 @@ def main():
         print(t_process("[>] SSL flag set, sending all results over HTTPS."))
 
     if(arguments.add_waf_bypass_headers):
-        print(t_process("[>] WAF flag set, sending simple WAF bypass headers."))
+        print(t_process(
+            "[>] WAF flag set, sending simple WAF bypass headers."
+        ))
 
-    print(t_process("[>] Ignoring HTTP codes: {}".format(arguments.ignore_http_codes)))
+    print(t_process(
+        "[>] Ignoring HTTP codes: {}".format(arguments.ignore_http_codes)
+    ))
 
     if(arguments.ignore_content_length > 0):
         print(t_process(
@@ -86,7 +99,9 @@ def main():
 
     if not arguments.no_lookup:
         try:
-            print(t_process("[+] Resolving DNS for additional wordlist entries"))
+            print(t_process(
+                "[+] Resolving DNS for additional wordlist entries"
+            ))
             for ip in dns.resolver.query(arguments.target_hosts, 'A'):
                 host, aliases, ips = gethostbyaddr(str(ip))
                 wordlist.append(str(ip))
@@ -101,7 +116,9 @@ def main():
             print(t_error("[!] Couldn't find any records (NoAnswer)"))
 
     if arguments.verbose:
-        print(t_process("[>] Scanning with %s items in wordlist" % len(wordlist)))
+        print(t_process(
+            "[>] Scanning with %s items in wordlist" % len(wordlist)
+        ))
 
     scanner_args = vars(arguments)
     scanner_args.update({
@@ -112,7 +129,7 @@ def main():
 
     scanner = virtual_host_scanner(**scanner_args)
     scanner.scan()
-    
+
     output = output_helper(scanner, arguments)
 
     print(output.output_normal_likely())
@@ -122,15 +139,21 @@ def main():
 
     if(arguments.output_normal):
         output.write_normal(arguments.output_normal)
-        print(t_process("\n[+] Writing normal ouptut to %s" % arguments.output_normal))
+        print(t_process(
+            "\n[+] Writing normal ouptut to %s" % arguments.output_normal
+        ))
 
     if(arguments.output_json):
         output.output_json(arguments.output_json)
-        print(t_process("\n[+] Writing json output to %s" % arguments.output_json))
+        print(t_process(
+            "\n[+] Writing json output to %s" % arguments.output_json
+        ))
 
     if(arguments.output_grepable):
         output.output_grepable(arguments.output_grepable)
-        print(t_process("\n[+] Writing grepable ouptut to %s" % arguments.output_json))
+        print(t_process(
+            "\n[+] Writing grepable ouptut to %s" % arguments.output_json
+        ))
 
 
 if __name__ == "__main__":

--- a/VHostScan/VHostScan.py
+++ b/VHostScan/VHostScan.py
@@ -44,7 +44,7 @@ def extract_arguments():
 def main():
     arguments = extract_arguments()
 
-    config_colorization(arguments.use_color)
+    config_colorization(arguments.no_color)
 
     print_banner()
 

--- a/VHostScan/lib/core/virtual_host_scanner.py
+++ b/VHostScan/lib/core/virtual_host_scanner.py
@@ -116,7 +116,9 @@ class virtual_host_scanner(object):
             hostname = virtual_host.replace('%s', self.base_host)
 
             if self.verbose:
-                print(t_process("[*] Scanning {hostname}".format(hostname=hostname)))
+                print(t_process(
+                    "[*] Scanning {hostname}".format(hostname=hostname)
+                ))
 
             if self.real_port == 80:
                 host_header = hostname
@@ -202,12 +204,13 @@ class virtual_host_scanner(object):
         Creates a host using the responce and the hash.
         Prints current result in real time.
         """
-        output = t_result_head('[#] Found: {} (code: {}, length: {}, hash: {})\n'.format(
-            hostname,
-            response.status_code,
-            response.headers.get('content-length'),
-            page_hash
-        ))
+        output = t_result_head(
+            '[#] Found: {} (code: {}, length: {}, hash: {})\n'.format(
+                hostname,
+                response.status_code,
+                response.headers.get('content-length'),
+                page_hash
+            ))
 
         host = discovered_host()
         host.hostname = hostname
@@ -216,7 +219,9 @@ class virtual_host_scanner(object):
         host.contnet = response.content
 
         for key, val in response.headers.items():
-            output += ('  {}'+t_key(':')+' {}\n').format(t_key(key), t_result(val))
+            output += ('  {}'+t_key(':')+' {}\n').format(
+                t_key(key), t_result(val)
+            )
             host.keys.append('{}: {}'.format(key, val))
 
         print(output)

--- a/VHostScan/lib/core/virtual_host_scanner.py
+++ b/VHostScan/lib/core/virtual_host_scanner.py
@@ -6,6 +6,8 @@ import hashlib
 import pandas as pd
 import time
 from .discovered_host import *
+from ..helpers.color_helper import *
+
 
 import urllib3
 urllib3.disable_warnings()
@@ -114,7 +116,7 @@ class virtual_host_scanner(object):
             hostname = virtual_host.replace('%s', self.base_host)
 
             if self.verbose:
-                print("[*] Scanning {hostname}".format(hostname=hostname))
+                print(t_process("[*] Scanning {hostname}".format(hostname=hostname)))
 
             if self.real_port == 80:
                 host_header = hostname
@@ -174,8 +176,8 @@ class virtual_host_scanner(object):
 
     def likely_matches(self):
         if self.completed_scan is False:
-            print("[!] Likely matches cannot be printed "
-                  "as a scan has not yet been run.")
+            print(t_error("[!] Likely matches cannot be printed "
+                  "as a scan has not yet been run."))
             return
 
         # segment results from previous scan into usable results
@@ -200,12 +202,12 @@ class virtual_host_scanner(object):
         Creates a host using the responce and the hash.
         Prints current result in real time.
         """
-        output = '[#] Found: {} (code: {}, length: {}, hash: {})\n'.format(
+        output = t_result_head('[#] Found: {} (code: {}, length: {}, hash: {})\n'.format(
             hostname,
             response.status_code,
             response.headers.get('content-length'),
             page_hash
-        )
+        ))
 
         host = discovered_host()
         host.hostname = hostname
@@ -214,7 +216,7 @@ class virtual_host_scanner(object):
         host.contnet = response.content
 
         for key, val in response.headers.items():
-            output += '  {}: {}\n'.format(key, val)
+            output += ('  {}'+t_key(':')+' {}\n').format(t_key(key), t_result(val))
             host.keys.append('{}: {}'.format(key, val))
 
         print(output)

--- a/VHostScan/lib/helpers/color_helper.py
+++ b/VHostScan/lib/helpers/color_helper.py
@@ -47,12 +47,12 @@ def __convert_to_color(value, color, attrs):
 
 # color-based converter functions
 for color in all_colors:
-    exec('def t_{0} (value, attrs=[]): ' +
-         'return __convert_to_color(value, "{0}", attrs)'.format(color))
+    exec('def t_{} (value, attrs=[]): '.format(color) +
+         'return __convert_to_color(value, "{}", attrs)'.format(color))
 
 for purpose, args in text_settings.items():
-    exec('def t_{0} (value): ' +
-         'return t_{1}(value, attrs={2})'.format(purpose, *args))
+    exec('def t_{} (value): '.format(color) +
+         'return t_{}(value, attrs={})'.format(*args))
 
 '''
 # purpose-based converter functions

--- a/VHostScan/lib/helpers/color_helper.py
+++ b/VHostScan/lib/helpers/color_helper.py
@@ -33,11 +33,13 @@ avalable attributes
     'concealed'
 """
 
-def config_colorization (enabled):
+
+def config_colorization(enabled):
     global __COLOR_ENABLED
     __COLOR_ENABLED = False if enabled == 'FALSE' else True
-    
-def __convert_to_color (value, color, attrs):
+
+
+def __convert_to_color(value, color, attrs):
     if __COLOR_ENABLED:
         return colored(str(value), color, attrs=attrs)
     else:
@@ -45,10 +47,12 @@ def __convert_to_color (value, color, attrs):
 
 # color-based converter functions
 for color in all_colors:
-    exec('def t_{0} (value, attrs=[]): return __convert_to_color(value, "{0}", attrs)'.format(color))
+    exec('def t_{0} (value, attrs=[]): ' +
+         'return __convert_to_color(value, "{0}", attrs)'.format(color))
 
 for purpose, args in text_settings.items():
-    exec('def t_{0} (value): return t_{1}(value, attrs={2})'.format(purpose, *args))
+    exec('def t_{0} (value): ' +
+         'return t_{1}(value, attrs={2})'.format(purpose, *args))
 
 '''
 # purpose-based converter functions
@@ -79,7 +83,7 @@ def print_process (value, *a):
 
 def print_result_head (value, *a):
     print(t_result_head(value), *a)
-    
+
 def print_result (value, *a):
     print(t_result(value), *a)
 
@@ -88,7 +92,7 @@ def print_key (value, *a):
 
 def print_link (value, *a):
     print(t_link(value), *a)
-    
+
 def print_error (value, *a):
     print(t_error(value), *a)
 

--- a/VHostScan/lib/helpers/color_helper.py
+++ b/VHostScan/lib/helpers/color_helper.py
@@ -1,0 +1,100 @@
+from termcolor import colored
+
+__COLOR_ENABLED = True
+
+text_settings = {
+    'process':      ('cyan', []),
+    'result_head':  ('magenta', []),
+    'result':       ('white', []),
+    'key':          ('yellow', []),
+    'link':         ('green', ['underline']),
+    'error':        ('red', ['bold']),
+    'warning':      ('red', ['bold', 'dark']),
+}
+
+all_colors = [
+    'grey',
+    'red',
+    'green',
+    'yellow',
+    'blue',
+    'magenta',
+    'cyan',
+    'white'
+]
+
+"""
+avalable attributes
+    'bold'
+    'dark'
+    'underline'
+    'blink'
+    'reverse'
+    'concealed'
+"""
+
+def config_colorization (enabled):
+    global __COLOR_ENABLED
+    __COLOR_ENABLED = False if enabled == 'FALSE' else True
+    
+def __convert_to_color (value, color, attrs):
+    if __COLOR_ENABLED:
+        return colored(str(value), color, attrs=attrs)
+    else:
+        return str(value)
+
+# color-based converter functions
+for color in all_colors:
+    exec('def t_{0} (value, attrs=[]): return __convert_to_color(value, "{0}", attrs)'.format(color))
+
+for purpose, args in text_settings.items():
+    exec('def t_{0} (value): return t_{1}(value, attrs={2})'.format(purpose, *args))
+
+'''
+# purpose-based converter functions
+def t_process (value):
+    return t_cyan(value)
+
+def t_result_head (value):
+    return t_magenta(value)
+
+def t_result (value):
+    return t_white(value)
+
+def t_key (value):
+    return t_yellow(value)
+
+def t_link (value):
+    return t_green(value, attrs=['underline'])
+
+def t_error (value):
+    return t_red(value, attrs=['bold'])
+
+def t_warning (value):
+    return t_red(value, attrs=['bold','dark'])
+
+# print wrapping for convenience
+def print_process (value, *a):
+    print(t_process(value), *a)
+
+def print_result_head (value, *a):
+    print(t_result_head(value), *a)
+    
+def print_result (value, *a):
+    print(t_result(value), *a)
+
+def print_key (value, *a):
+    print(t_key(value), *a)
+
+def print_link (value, *a):
+    print(t_link(value), *a)
+    
+def print_error (value, *a):
+    print(t_error(value), *a)
+
+def print_warning (value, *a):
+    print(t_warning(value) *a)
+
+def _expand_print (func, *a):
+    print(*map(func,a))
+'''

--- a/VHostScan/lib/helpers/color_helper.py
+++ b/VHostScan/lib/helpers/color_helper.py
@@ -34,9 +34,9 @@ avalable attributes
 """
 
 
-def config_colorization(enabled):
+def config_colorization(no_color):
     global __COLOR_ENABLED
-    __COLOR_ENABLED = False if enabled == 'FALSE' else True
+    __COLOR_ENABLED = not no_color
 
 
 def __convert_to_color(value, color, attrs):

--- a/VHostScan/lib/helpers/file_helper.py
+++ b/VHostScan/lib/helpers/file_helper.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from pkg_resources import resource_filename
+from .color_helper import *
 
 DEFAULT_UA_LIST = resource_filename(
     'VHostScan', 'lib/ua-random-list.txt')
@@ -20,7 +21,7 @@ class file_helper(object):
                 os.stat(directory)
             except:
                 os.mkdir(directory)
-                print("[!] %s didn't exist and has been created." % directory)
+                print(t_error("[!] %s didn't exist and has been created." % directory))
 
     def is_json(json_file):
         try:

--- a/VHostScan/lib/helpers/file_helper.py
+++ b/VHostScan/lib/helpers/file_helper.py
@@ -21,7 +21,9 @@ class file_helper(object):
                 os.stat(directory)
             except:
                 os.mkdir(directory)
-                print(t_error("[!] %s didn't exist and has been created." % directory))
+                print(t_error(
+                    "[!] %s didn't exist and has been created." % directory
+                ))
 
     def is_json(json_file):
         try:

--- a/VHostScan/lib/helpers/output_helper.py
+++ b/VHostScan/lib/helpers/output_helper.py
@@ -1,5 +1,6 @@
 from ..core.discovered_host import *
 from .file_helper import *
+from .color_helper import *
 import time
 from fuzzywuzzy import fuzz
 import itertools
@@ -44,11 +45,11 @@ class output_helper(object):
             uniques = True
 
         if(uniques):
-            return output
+            return t_process(output)
         else:
-            return (
+            return t_error((
                 "\n[!] No matches with an"
-                " unique count of {} or less.").format(depth)
+                " unique count of {} or less.").format(depth))
 
     def output_json(self, filename):
         file = file_helper(filename)
@@ -82,7 +83,7 @@ class output_helper(object):
         output['Result'] = result
 
         if not file.is_json(output):
-            print("[!] Json format check failed")
+            print(t_error("[!] Json format check failed"))
 
         file.write_file(json.dumps(output, indent=2))
 

--- a/VHostScan/lib/input.py
+++ b/VHostScan/lib/input.py
@@ -34,9 +34,8 @@ class cli_argument_parser(object):
         )
 
         parser.add_argument(
-            '-c', dest='use_color', default='TRUE',
-            help='Enable/Disable colorization '
-                 'FALSE = off, TRUE = on (default TRUE)'
+            '--no-color', dest='no_color', default=False,
+            help='Disable colorization on interface.'
         )
 
         parser.add_argument(

--- a/VHostScan/lib/input.py
+++ b/VHostScan/lib/input.py
@@ -38,7 +38,7 @@ class cli_argument_parser(object):
             help='Enable/Disable colorization '
                  'FALSE = off, TRUE = on (default TRUE)'
         )
-        
+
         parser.add_argument(
             '-p', dest='port', default=80, type=int,
             help='Set the port to use (default 80).'

--- a/VHostScan/lib/input.py
+++ b/VHostScan/lib/input.py
@@ -34,6 +34,12 @@ class cli_argument_parser(object):
         )
 
         parser.add_argument(
+            '-c', dest='use_color', default='TRUE',
+            help='Enable/Disable colorization '
+                 'FALSE = off, TRUE = on (default TRUE)'
+        )
+        
+        parser.add_argument(
             '-p', dest='port', default=80, type=int,
             help='Set the port to use (default 80).'
         )

--- a/VHostScan/lib/input.py
+++ b/VHostScan/lib/input.py
@@ -34,7 +34,7 @@ class cli_argument_parser(object):
         )
 
         parser.add_argument(
-            '--no-color', dest='no_color', default=False,
+            '--no-color', dest='no_color', action='store_true', default=False,
             help='Disable colorization on interface.'
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==0.19.2
 requests==2.10.0
 simplejson==3.8.2
 urllib3==1.20
+termcolor==1.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest==3.2.3
 pytest-mock==1.6.3
 pep8==1.7.0
-termcolor=1.1.0
+termcolor==1.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest==3.2.3
 pytest-mock==1.6.3
 pep8==1.7.0
+termcolor=1.1.0

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -34,7 +34,8 @@ def test_parse_arguments_default_value(tmpdir):
         'ssl': False,
         'prefix': False,
         'suffix': False,
-        'verbose': False
+        'verbose': False,
+        'no-color': False
     }
     
     assert vars(arguments) == expected_arguments
@@ -64,7 +65,8 @@ def test_parse_arguments_custom_arguments(tmpdir):
         '-oN', '/tmp/on',
         '--prefix','dev-',
         '--suffix','test',
-        '-v'
+        '-v',
+        '--no-color'
     ]
 
     arguments = cli_argument_parser().parse(argv)
@@ -92,7 +94,7 @@ def test_parse_arguments_custom_arguments(tmpdir):
         'prefix': 'dev-',
         'suffix': 'test',
         'verbose': True,
-        'no_color': False
+        'no_color': True
     }
 
     assert vars(arguments) == expected_arguments

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -35,7 +35,7 @@ def test_parse_arguments_default_value(tmpdir):
         'prefix': False,
         'suffix': False,
         'verbose': False,
-        'no-color': False
+        'no_color': False
     }
     
     assert vars(arguments) == expected_arguments

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -91,7 +91,8 @@ def test_parse_arguments_custom_arguments(tmpdir):
         'output_grepable' : None,
         'prefix': 'dev-',
         'suffix': 'test',
-        'verbose': True
+        'verbose': True,
+        'no_color': False
     }
 
     assert vars(arguments) == expected_arguments


### PR DESCRIPTION
User can disable this option by entering argument -c FALSE

I used termcolor module https://pypi.org/project/termcolor/ to paint text with colors to improve readability of the interface. 

There are some limitation of the module depending on terminal brands which is described in the link above.

I am not confident about the quality of my code. I think it needs a lot further refinement to match the overall quality standard of this repository, so it will be a great favor if you can leave me some comments or guidance about the improvement.