### PR TITLE
Remove is_json function

### DIFF
--- a/VHostScan/lib/helpers/file_helper.py
+++ b/VHostScan/lib/helpers/file_helper.py
@@ -23,14 +23,6 @@ class file_helper(object):
                 print("[!] {} didn't exist and has been created.".format(
                     directory))
 
-    def is_json(json_file):
-        try:
-            with open(json_file, "r") as f:
-                json_object = json.load(f)
-        except ValueError:
-            return False
-        return True
-
     def write_file(self, contents):
         # check if host directory exists, if not create it
         self.check_directory()

--- a/VHostScan/lib/helpers/output_helper.py
+++ b/VHostScan/lib/helpers/output_helper.py
@@ -83,9 +83,6 @@ class output_helper(object):
 
         output['Result'] = result
 
-        if not file.is_json(output):
-            print("[!] Json format check failed")
-
         file.write_file(json.dumps(output, indent=2))
 
     def output_fuzzy(self):


### PR DESCRIPTION
Writing output to a JSON file is not working and due to the is_json errors
(see issue #113). The function seems to check if the content of a file is JSON
but this seems not to be needed since file_helper will overwrite the file.