### PR TITLE
Fix VHostScan installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,6 @@ This project includes a small battery of tests. It's really simple to run the te
 
 ```bash
 pip install -r test-requirements.txt
-pytest
-```
-
-Or you can optionally run:
-
-```bash
-pip install -r test-requirements.txt
 python3 setup.py test
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-dnspython==1.15.0
-fuzzywuzzy==0.15.1
-numpy==1.12.0
-pandas==0.19.2
-requests==2.20.0
-simplejson==3.8.2
-urllib3==1.24.2
+dnspython
+fuzzywuzzy
+numpy
+pandas
+requests
+simplejson
+urllib3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-pytest==3.2.3
-pytest-mock==1.6.3
-pep8==1.7.0
+pytest
+pytest-mock
+pep8


### PR DESCRIPTION
People seem to be struggling to install VHostScan as in issues [#122](https://github.com/codingo/VHostScan/issues/122) and [#123](https://github.com/codingo/VHostScan/issues/123) and I found that by removing the version numbers in `requirements.txt` The install and test scripts would run flawlessly. 

I also updated `test-requirements.txt` to follow the same "version numbering" in both `*.txt` files. 

Lastly, I removed `pytest` command example from the `README.md` because it uses python2 which is now deprecated. The problem with it is that it was trying to import the `ipaddress` module and since `pip2` is not available, it would be problem to install it and keep building on top of it. 

In conclusion the following commands should run without issues:

```bash
sudo python3 setup.py install
sudo python3 setup.py test
```